### PR TITLE
feat(mothership): enable knowledge router in api_routes

### DIFF
--- a/config/api_routes.yaml
+++ b/config/api_routes.yaml
@@ -34,3 +34,5 @@ routers:
   - module: "application.mothership.routers.intelligence:router"
     prefix: "/intelligence"
     enabled: true
+  - module: "application.mothership.routers.knowledge:router"
+    enabled: true


### PR DESCRIPTION
## Summary
- Registers `application.mothership.routers.knowledge:router` in `config/api_routes.yaml` so the knowledge API is mounted with other v1 Mothership routers.

## Notes
- Local-only `dev/` scratch and DB backups were not included.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that mounts an additional API router; main risk is exposing new endpoints or startup/import failures if the router module is misconfigured.
> 
> **Overview**
> Adds `application.mothership.routers.knowledge:router` to `config/api_routes.yaml` and enables it so the Knowledge API is mounted alongside other `/api/v1` Mothership routers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f83697aa044dbe8adac631887846c37f6db69ee6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->