### PR TITLE
fix: correct artifact download path to avoid dist/dist nesting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: dist-packages
-          path: dist/
+          path: .
 
       - name: "Publish to PyPI"
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -290,7 +290,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: dist-packages
-          path: dist/
+          path: .
 
       - name: "Download Release Notes"
         uses: actions/download-artifact@v7


### PR DESCRIPTION
Copilot-generated fix for nested dist directory in artifact download paths. Single commit, low risk.